### PR TITLE
Issue #2 -- Moved hardcoded configuration to an ini file

### DIFF
--- a/alarm_central_station_receiver/alarm.py
+++ b/alarm_central_station_receiver/alarm.py
@@ -15,7 +15,8 @@ limitations under the License.
 """
 import logging
 import time
-import RPi.GPIO as GPIO
+# XXX Comment out for now
+#import RPi.GPIO as GPIO
 from json import dumps
 from collections import deque
 from contact_id import dsc
@@ -27,7 +28,8 @@ class Alarm(object):
         self.system_status = "ok"
         self.history = deque()
         self.outstanding = {}
-        self._initialize_rpi_gpio()
+		# XXX gracefully handle if someone does not have a raspberry pi
+        #self._initialize_rpi_gpio()
 
     def _update_system_status(self):
         """

--- a/alarm_central_station_receiver/alarm_config.py
+++ b/alarm_central_station_receiver/alarm_config.py
@@ -1,0 +1,54 @@
+import ConfigParser
+import shutil
+import os.path
+
+LOADED_CONFIG = {}
+
+class AlarmConfig:
+    @staticmethod
+    def exists(path):
+        return os.path.isfile(path)
+
+    @staticmethod
+    def load(path):
+        config = ConfigParser.ConfigParser()
+        config.read(path)
+        global LOADED_CONFIG
+        LOADED_CONFIG = { key : dict( config.items(key) ) for key in config.sections() }
+
+    @staticmethod
+    def get(*argv):
+        config = LOADED_CONFIG
+        for arg in argv:
+            config = config.get(arg, {})
+
+        return config
+
+    @staticmethod
+    def validate(config):
+        missing_config = []
+        if not config.get('AlarmSystem').get('phone_number'):
+            missing_config.append('[AlarmSystem] Section: phone_number')
+
+        email_keywords = ['username',
+                          'password',
+                          'server_address',
+                          'port',
+                          'notification_email']
+
+        email_config = config.get('EmailNotification')
+        for keyword in email_keywords:
+            if not email_config.get(keyword):
+                missing_config.append('[EmailNotification] Section: %s' % keyword)
+
+        return missing_config
+
+    @staticmethod
+    def create(path):
+        if not AlarmConfig.exists(path):
+            shutil.copy(os.path.abspath(
+                os.path.join(os.path.dirname(__file__), 'config_template.ini')),
+                path)
+            return True
+
+        return False

--- a/alarm_central_station_receiver/config_template.ini
+++ b/alarm_central_station_receiver/config_template.ini
@@ -1,0 +1,50 @@
+##############################################################################
+#
+# Required Configuration
+#
+# Set this to the phone number that your alarm system will 'call'.  When the
+# daemon detects the alarm system dialing this number it will answer the phone
+# and initiate the contact-id handshake.
+#
+##############################################################################
+[AlarmSystem]
+phone_number =
+
+
+##############################################################################
+#
+# Required Configuration
+#
+# Configuration to send notifications to an email address.
+#
+# To receive notifications via SMS, set 'notification_email' to your cell phone
+# service's email to text address. For example: 5551234567@txt.att.net,
+# 5551234567@vtext.com, or 5551234567@tmomail.net
+#
+##############################################################################
+[EmailNotification]
+notification_email =
+username =
+password =
+server_address =
+port =
+
+
+##############################################################################
+#
+# Optional Configuration
+#
+# Names for your alarm sensor zones.  These will be sent in the notification
+# messages. Any unnamed zones are listed as "Zone XXX" in the notification message.
+# Format is "ZXXX = Label" where XXX is your zone numbers.
+#
+# Sample:
+# 001 =  Front Door
+# 002 =  Garage Window
+# ...
+# 023 =  Kitchen Window
+#
+##############################################################################
+[ZoneMapping]
+001 =
+002 =

--- a/alarm_central_station_receiver/contact_id/dsc.py
+++ b/alarm_central_station_receiver/contact_id/dsc.py
@@ -1,6 +1,7 @@
 """
 DSC Contact ID Codes to Descriptions
 """
+from ..alarm_config import AlarmConfig
 
 EVENTS = {
     '100000': {'1': ('A', 'Aux Key Alarm')},
@@ -78,20 +79,6 @@ EVENTS = {
     '654000': {'1': ('MA', 'Delinquency')}
     }
 
-ZONES = {
-    '001' : 'Front Door',
-    '002' : 'Inside Garage Door',
-    '003' : 'Kitchen Window',
-    '004' : 'Outside Garage Door',
-    '005' : 'Motion Sensor',
-    '006' : 'Left Dining Room Window',
-    '007' : 'Right Dining Room Window',
-    '008' : 'Left Family Window',
-    '009' : 'Middle Family Window',
-    '010' : 'Right Family Window',
-    '011' : 'Kitchen Door',
-    }
-
 def create_event_description(event_type, event):
     """
     Create the alarm description by using the '1' event type
@@ -112,6 +99,13 @@ def create_event_description(event_type, event):
         description += 'Unknown Event Type'
 
     return event_type_name, description
+
+def get_zone_name(sensor_code):
+    zone_name = AlarmConfig.get('ZoneMapping', sensor_code)
+    if not zone_name:
+        zone_name = 'Zone %s' % sensor_code
+
+    return zone_name
 
 def digits_to_alarmreport(code):
     """
@@ -138,7 +132,7 @@ def digits_to_alarmreport(code):
         user_event = EVENTS.get(event_code + 'UUU')
         if zone_event:
             event = zone_event
-            zone_name = ZONES.get(sensor_code, 'Unknown Zone')
+            zone_name = get_zone_name(sensor_code)
             extra_desc = ' %s (%s)' % (zone_name, sensor_code)
         elif user_event:
             event = user_event

--- a/alarm_central_station_receiver/notifications/email_notify.py
+++ b/alarm_central_station_receiver/notifications/email_notify.py
@@ -19,38 +19,29 @@ import multiprocessing
 import smtplib
 from email.mime.text import MIMEText
 from email.mime.multipart import MIMEMultipart
-
-contact_info = {
-    'user' : '',
-    'password' : '',
-    'to' : '',
-    'server' : '',
-    'port' : 587
-}
-
-def settings_missing():
-    return '' in contact_info.values()
+from ..alarm_config import AlarmConfig
 
 def send_email(message):
-    if settings_missing():
-        logging.info("Skipping Email send, no settings in email_notify.py")
-        return
-        
     logging.info("Sending Email...")
+    username = AlarmConfig.get('EmailNotification', 'username')
+    password = AlarmConfig.get('EmailNotification', 'password')
+    to_addr = AlarmConfig.get('EmailNotification', 'notification_email')
+    server = AlarmConfig.get('EmailNotification', 'server_address')
+    server_port = AlarmConfig.get('EmailNotification', 'port')
 
     msg = MIMEMultipart('alternative')
-    msg['From'] = contact_info['user']
-    msg['To'] = contact_info['to']
+    msg['From'] = username
+    msg['To'] = to_addr
     body = "%s:\n%s" % (time.strftime("%b %d %I:%M:%S %p"), '\n'.join(message))
     msg.attach(MIMEText(body, 'plain'))
     msg.attach(MIMEText(body, 'html'))
 
-    s = smtplib.SMTP(contact_info['server'], contact_info['port'])
+    s = smtplib.SMTP(server, server_port)
     s.ehlo()
     s.starttls()
     s.ehlo()
-    s.login(contact_info['user'], contact_info['password'])
-    s.sendmail(contact_info['user'], [contact_info['to']], msg.as_string())
+    s.login(username, password)
+    s.sendmail(username, [to_addr], msg.as_string())
     s.quit()
 
     logging.info("Email Send Complete")

--- a/setup.py
+++ b/setup.py
@@ -7,7 +7,7 @@ pytjapi = Extension(
 
 setup(
     name='alarm_central_station_receiver',
-    version='0.0.7',
+    version='0.0.8',
     author='Chris Scuderi',
     license='Apache License Version 2.0',
     description='Software based central station receiver for home alarm systems',
@@ -19,7 +19,7 @@ setup(
         'console_scripts': ['alarmd=alarm_central_station_receiver.main:main']
         },
     install_requires = [
-        'RPi.GPIO',
+        #XXX scud add support later 'RPi.GPIO',
         'pyaudio',
         'python-daemon'
     ]


### PR DESCRIPTION
1. Added template ini to project
1. Modified system to create blank config in '/etc/alarmd_config.ini' by default.  This supports setting email config, phone number alarm will call, and zone names
1. Added '--config' flag to specify non-default ini confg file location
1. Added '--create-config' flag to create a ini config file and exit.  This can be used in conjunction with '--config' to create the ini file 
1. Modified daemon to use config from ini instead of hardcoded values.

**Unrelated to Issue #2**
1. Commented out Raspberry PI GPIO config since it's not actively used
1. Cleaned up some cases of trailing whitespace.