### PR TITLE
alarm-ctl print arm/disarm message

### DIFF
--- a/alarm_central_station_receiver/alarm_ctl.py
+++ b/alarm_central_station_receiver/alarm_ctl.py
@@ -44,13 +44,18 @@ on the keypad, or with the regular arm command.
     args = parser.parse_args()
     check_running_root()
 
-    error_msg = send_client_msg({'command': args.command})
-    if not error_msg:
-        sys.stdout.write('Success')
-        return 0
+    rsp, serr = send_client_msg({'command': args.command})
+    if serr:
+        sys.stderr.write('%s\n' % serr)
+        return -1
 
-    sys.stderr.write('Error: %s', error_msg)
-    return -1
+    error_msg = rsp.get('error')
+    if error_msg:
+        sys.stderr.write('Error: %s\n' % error_msg)
+        return -1
+
+    sys.stdout.write('%s\n' % rsp.get('status'))
+    return 0
 
 
 if __name__ == "__main__":

--- a/alarm_central_station_receiver/json_ipc.py
+++ b/alarm_central_station_receiver/json_ipc.py
@@ -37,12 +37,17 @@ class ServerSock(object):
 
 
 def send_client_msg(request):
-    s = start_socket_client()
-    send(s, request)
-    rsp = recv(s)
-    s.close()
+    try:
+        serr = None
+        rsp = None
+        s = start_socket_client()
+        send(s, request)
+        rsp = recv(s)
+        s.close()
+    except socket.error as exc:
+        serr = 'Exception: %s\nUnable to open socket, is alarmd running?' % exc
 
-    return rsp.get('error')
+    return rsp, serr
 
 
 def start_socket_client():

--- a/alarm_central_station_receiver/main.py
+++ b/alarm_central_station_receiver/main.py
@@ -124,11 +124,11 @@ def process_sock_request(sockfd, alarm_system):
         command = msg.get('command')
         auto_arm = True if 'auto' in command else False
         if command in ['arm', 'auto-arm']:
-            alarm_system.arm(auto_arm)
-            rsp = {'error': False}
+            status = alarm_system.arm(auto_arm)
+            rsp = {'error': False, 'status': status}
         elif command in ['disarm', 'auto-disarm']:
-            alarm_system.disarm(auto_arm)
-            rsp = {'error': False}
+            status = alarm_system.disarm(auto_arm)
+            rsp = {'error': False, 'status': status}
         else:
             rsp = {'error': 'Invalid command %s' % command}
 

--- a/alarm_central_station_receiver/system.py
+++ b/alarm_central_station_receiver/system.py
@@ -74,31 +74,37 @@ class AlarmSystem(object):
             return
 
         if self.alarm.arm_status in ['armed', 'arming']:
-            logging.info('System already %s, ignoring request',
-                         self.alarm.arm_status)
-            return
+            status = 'System already %s, ignoring request' % self.alarm.arm_status
+            logging.info(status)
+            return status
 
-        logging.info('Arming system%s...',
-                     ' in auto mode' if auto_arm else '')
+        status = 'Arming system%s...' % (' in auto mode' if auto_arm else '')
+        logging.info(status)
+
         self._trip_keyswitch()
         self.alarm.arm_status = 'arming'
         self.alarm.auto_arm = auto_arm
         self.alarm.save_data()
+
+        return status
 
     def disarm(self, auto_arm):
         if not self.valid_setup():
             return
 
         if self.alarm.arm_status in ['disarming', 'disarmed']:
-            logging.info('System already %s, ignoring request',
-                         self.alarm.arm_status)
-            return
+            status = 'System already %s, ignoring request' % self.alarm.arm_status
+            logging.info(status)
+
+            return status
 
         if auto_arm and not self.alarm.auto_arm:
-            logging.info('System manually armed, skipping auto disarm')
-            return
+            status = 'System manually armed, skipping auto disarm'
+            logging.info(status)
+            return status
 
-        logging.info('Disarming system...')
+        status = 'Disarming system...'
+        logging.info(status)
         self._trip_keyswitch()
 
         # If the system wasn't fully armed, there won't be an event
@@ -110,3 +116,5 @@ class AlarmSystem(object):
             self.alarm.arm_status = 'disarming'
 
         self.alarm.save_data()
+
+        return status


### PR DESCRIPTION
When using alarm-ctl print out the status message from the alarm on arm/disarm instead of simply 'Success'.