### PR TITLE
Refactored code parsing to improve performance

### DIFF
--- a/alarm_central_station_receiver/contact_id/decoder.py
+++ b/alarm_central_station_receiver/contact_id/decoder.py
@@ -30,17 +30,15 @@ def create_event(rtype, description, eid):
 def decode(raw_events):
     decoded_events = []
 
-    for err, code in raw_events:
-        if not err:
-            report_type, description = dsc.digits_to_alarmreport(code)
-        else:
+    for code, valid in raw_events:
+        if len(code) < 15:
             report_type = 'U'
-            if len(code) != 16:
-                description = \
-                    'Leftover Bits: %s (len %d)' % (code, len(code))
-            else:
-                description = \
-                    'Checksum Mismatch: %s' % code
+            description = 'Invalid Length: %s (len %d)' % (code, len(code))
+        else:
+            # Attempt to decode even with a bad checksum
+            report_type, description = dsc.digits_to_alarmreport(code)
+            if not valid:
+                description += ' -- Checksum Mismatch! %s' % code
 
         decoded_events.append(create_event(report_type,
                                            description,


### PR DESCRIPTION
In some cases it seems that DTMF digits are not collected fast enough from the TigerJet fd.  To simplify the logic, instead of attempting to collect the codes and calculate the checksum at the same time, it now will:

1) Collect the codes as a single large string
2) Hang up with the alarm system
3) Then use a regex to find all of the 15 or 16 length contact-id strings
4) Calculate the checksum per code

Also changed up how the checksum validation errors are handled.  Previously if the checksum was invalid decoding of the contact ID string was not even attempted.  Though it seems that in majority, if not all cases, where the checksum isn't valid the alarm string still may be.  So now decoding of the DTMF string will always be attempted, and if the checksum is invalid, this will be appended to notification message.
