### PR TITLE
Expose ConfigParser APIs via AlarmConfig -- Issue #13

### DIFF
--- a/alarm_central_station_receiver/config.py
+++ b/alarm_central_station_receiver/config.py
@@ -70,23 +70,22 @@ class AlarmConfig(object):
         klass.config = configparser.ConfigParser()
         klass.config.read(path)
 
-    @staticmethod
-    def validate(config):
+    @classmethod
+    def validate(klass):
         missing_config = []
 
         for sec_name, section in CONFIG_MAP.items():
-            optional = not section.get('required')
-            missing = not config.get(sec_name)
+            required = section.get('required')
+            missing = not klass.config.get(sec_name)
 
             # If an entire section is missing, and its an optional
             # section, skip validation.
-            if optional and missing:
+            if missing and not required:
                 continue
 
             for key, key_required in section.get('keys', {}).items():
-                cfg_value = config.get(sec_name, {}).get(key, '')
-
-                if key_required and cfg_value == '':
+                cfg_value = klass.config.get(sec_name, key, fallback=None)
+                if key_required and not cfg_value:
                     missing_config.append('[%s] Section: %s' % (sec_name, key))
 
         return missing_config

--- a/alarm_central_station_receiver/config.py
+++ b/alarm_central_station_receiver/config.py
@@ -76,7 +76,7 @@ class AlarmConfig(object):
 
         for sec_name, section in CONFIG_MAP.items():
             required = section.get('required')
-            missing = not klass.config.get(sec_name)
+            missing = sec_name not in klass.config
 
             # If an entire section is missing, and its an optional
             # section, skip validation.

--- a/alarm_central_station_receiver/config.py
+++ b/alarm_central_station_receiver/config.py
@@ -59,7 +59,7 @@ CONFIG_MAP = {
 
 
 class AlarmConfig(object):
-    loaded_config = {}
+    config = None
 
     @staticmethod
     def exists(path):
@@ -67,18 +67,8 @@ class AlarmConfig(object):
 
     @classmethod
     def load(klass, path):
-        config = configparser.ConfigParser()
-        config.read(path)
-        klass.loaded_config = {key: dict(config.items(key))
-                               for key in config.sections()}
-
-    @classmethod
-    def get(klass, *argv):
-        config = klass.loaded_config
-        for arg in argv:
-            config = config.get(arg, {})
-
-        return config
+        klass.config = configparser.ConfigParser()
+        klass.config.read(path)
 
     @staticmethod
     def validate(config):

--- a/alarm_central_station_receiver/config_template.ini
+++ b/alarm_central_station_receiver/config_template.ini
@@ -30,9 +30,9 @@ phone_number =
 # connected to your RaspberrryPi
 #
 #############################################################################
-#
-# [RpiArmDisarm]
-# gpio_pin = 15
+
+#[RpiArmDisarm]
+#gpio_pin = 15
 
 
 ##############################################################################
@@ -50,10 +50,10 @@ phone_number =
 # 023 =  Kitchen Window
 #
 ##############################################################################
-#
-# [ZoneMapping]
-# 001 =
-# 002 =
+
+#[ZoneMapping]
+#001 =
+#002 =
 
 ##############################################################################
 #
@@ -66,15 +66,15 @@ phone_number =
 # 5551234567@vtext.com, or 5551234567@tmomail.net
 #
 ##############################################################################
-#
-# [EmailNotification]
-# notification_email =
-# notification_subject = Alarm Notification
-# username =
-# password =
-# server_address =
-# port =
-# tls = true
+
+#[EmailNotification]
+#notification_email =
+#notification_subject = Alarm Notification
+#username =
+#password =
+#server_address =
+#port =
+#tls = true
 
 ##############################################################################
 #
@@ -83,18 +83,18 @@ phone_number =
 # Uncomment if you want to configure notifications via pushover
 #
 ##############################################################################
+
+#[PushoverNotification]
+## Your user key which is found on your main dashboard
+#user =
 #
-# [PushoverNotification]
-# # Your user key which is found on your main dashboard
-# user =
+## Application token.  You'll need to create a new one here: https://pushover.net/apps/build
+#token =
 #
-# # Application token.  You'll need to create a new one here: https://pushover.net/apps/build
-# token =
+## Optionsl if you want to specify a message prority: https://pushover.net/api#priority
+## Otherwise you can leave it blank 
+#priority =
 #
-# # Optionsl if you want to specify a message prority: https://pushover.net/api#priority
-# # Otherwise you can leave it blank 
-# priority =
-#
-# # Optional if you want to send to specific devices: https://pushover.net/api#identifiers
-# # Otherwise you can leave it blank
-# device = 
+## Optional if you want to send to specific devices: https://pushover.net/api#identifiers
+## Otherwise you can leave it blank
+#device = 

--- a/alarm_central_station_receiver/contact_id/dsc.py
+++ b/alarm_central_station_receiver/contact_id/dsc.py
@@ -103,7 +103,9 @@ def create_event_description(event_type, event):
 
 
 def get_zone_name(sensor_code):
-    zone_name = AlarmConfig.get('ZoneMapping', sensor_code)
+    zone_name = AlarmConfig.config.get('ZoneMapping',
+                                       sensor_code,
+                                       fallback=None)
     if not zone_name:
         zone_name = 'Zone %s' % sensor_code
 

--- a/alarm_central_station_receiver/main.py
+++ b/alarm_central_station_receiver/main.py
@@ -75,7 +75,7 @@ def create_or_check_required_config(path):
         AlarmConfig.create(path)
 
     AlarmConfig.load(path)
-    missing_config = AlarmConfig.validate(AlarmConfig.get())
+    missing_config = AlarmConfig.validate()
     if missing_config:
         logging.error(
             'The following required configuration is missing from %s\n\n', path)
@@ -164,7 +164,7 @@ def process_sock_request(sockfd, alarm_system):
 
 
 def alarm_main_loop():
-    phone_number = AlarmConfig.get('Main', 'phone_number')
+    phone_number = AlarmConfig.config.get('Main', 'phone_number')
     alarm_status = AlarmStatus()
     alarm_system = AlarmSystem()
 

--- a/alarm_central_station_receiver/notifications/notifiers/emailer.py
+++ b/alarm_central_station_receiver/notifications/notifiers/emailer.py
@@ -44,17 +44,17 @@ def notify(events):
     if not events:
         return
 
-    if not AlarmConfig.get('EmailNotification'):
+    if 'EmailNotification' not in AlarmConfig.config:
         return
 
     logging.info("Sending email...")
-    username = AlarmConfig.get('EmailNotification', 'username')
-    password = AlarmConfig.get('EmailNotification', 'password')
-    to_addr = AlarmConfig.get('EmailNotification', 'notification_email')
-    subject = AlarmConfig.get('EmailNotification', 'notification_subject')
-    tls = AlarmConfig.get('EmailNotification', 'tls')
-    server = AlarmConfig.get('EmailNotification', 'server_address')
-    server_port = AlarmConfig.get('EmailNotification', 'port')
+    username = AlarmConfig.config.get('EmailNotification', 'username')
+    password = AlarmConfig.config.get('EmailNotification', 'password')
+    to_addr = AlarmConfig.config.get('EmailNotification', 'notification_email')
+    subject = AlarmConfig.config.get('EmailNotification', 'notification_subject')
+    tls = AlarmConfig.config.getboolean('EmailNotification', 'tls')
+    server = AlarmConfig.config.get('EmailNotification', 'server_address')
+    server_port = AlarmConfig.config.get('EmailNotification', 'port')
 
     msg = MIMEMultipart('alternative')
     msg['From'] = username
@@ -67,7 +67,7 @@ def notify(events):
     try:
         s = smtplib.SMTP(server, server_port)
         s.ehlo()
-        if tls.lower() in ("yes", "true", "t", "1"):
+        if tls:
             s.starttls()
         s.ehlo()
         s.login(username, password)

--- a/alarm_central_station_receiver/notifications/notifiers/pushover.py
+++ b/alarm_central_station_receiver/notifications/notifiers/pushover.py
@@ -30,18 +30,18 @@ def create_message(events):
 def create_params(events):
     timestamp, message = create_message(events)
     data = {
-        'token': AlarmConfig.get('PushoverNotification', 'token'),
-        'user': AlarmConfig.get('PushoverNotification', 'user'),
+        'token': AlarmConfig.config.get('PushoverNotification', 'token'),
+        'user': AlarmConfig.config.get('PushoverNotification', 'user'),
         'timestamp': timestamp,
         'title': 'Alarm Notification',
         'message': message,
     }
 
-    device = AlarmConfig.get('PushoverNotification', 'device')
+    device = AlarmConfig.config.get('PushoverNotification', 'device', fallback=None)
     if device:
         data['device'] = device
 
-    priority = AlarmConfig.get('PushoverNotification', 'priority')
+    priority = AlarmConfig.config.get('PushoverNotification', 'priority', fallback=None)
     if priority:
         data['priority'] = priority
 
@@ -52,7 +52,7 @@ def notify(events):
     if not events:
         return
 
-    if not AlarmConfig.get('PushoverNotification'):
+    if 'PushoverNotification' not in AlarmConfig.config:
         return
 
     logging.info("Sending pushover notification...")

--- a/alarm_central_station_receiver/status.py
+++ b/alarm_central_station_receiver/status.py
@@ -40,8 +40,9 @@ def should_notify(event):
     using cron to arm/disarm the system automatically on a regular basis
     these event notifiations can get noisy.
     """
-    return event['type'] not in ['AO', 'AC'] or AlarmConfig.get(
-        'Main', 'notify_auto_events').lower() in ("yes", "1", "true")
+    return event['type'] not in [
+        'AO', 'AC'] or AlarmConfig.config.getboolean(
+        'Main', 'notify_auto_events')
 
 
 @Singleton
@@ -64,7 +65,7 @@ class AlarmStatus(object):
             super(AlarmStatus._klass, self).__setattr__(attr, value)
 
     def __init__(self):
-        self.datastore_path = AlarmConfig.get('Main', 'data_file_path')
+        self.datastore_path = AlarmConfig.config.get('Main', 'data_file_path')
         if not self.load_data():
             self.arm_status = 'disarmed'
             self.arm_status_time = 0

--- a/alarm_central_station_receiver/system.py
+++ b/alarm_central_station_receiver/system.py
@@ -62,7 +62,7 @@ class AlarmSystem(object):
         GPIO.setup(self.pin, GPIO.OUT)
 
     def __init__(self):
-        self.pin = int(AlarmConfig.get('RpiArmDisarm', 'gpio_pin'))
+        self.pin = AlarmConfig.config.getint('RpiArmDisarm', 'gpio_pin')
         if not self.valid_setup():
             return
 

--- a/alarm_central_station_receiver/system.py
+++ b/alarm_central_station_receiver/system.py
@@ -108,12 +108,13 @@ class AlarmSystem(object):
         self._trip_keyswitch()
 
         # If the system wasn't fully armed, there won't be an event
-        # from the alarm indicating arm/disrm
+        # from the alarm indicating arm/disarm
         if self.alarm.arm_status == 'arming':
             self.alarm.arm_status = 'disarmed'
             self.alarm.auto_arm = False
         else:
             self.alarm.arm_status = 'disarming'
+            self.alarm.auto_arm = auto_arm
 
         self.alarm.save_data()
 

--- a/alarm_central_station_receiver/system.py
+++ b/alarm_central_station_receiver/system.py
@@ -71,7 +71,7 @@ class AlarmSystem(object):
 
     def arm(self, auto_arm):
         if not self.valid_setup():
-            return
+            return None
 
         if self.alarm.arm_status in ['armed', 'arming']:
             status = 'System already %s, ignoring request' % self.alarm.arm_status
@@ -90,7 +90,7 @@ class AlarmSystem(object):
 
     def disarm(self, auto_arm):
         if not self.valid_setup():
-            return
+            return None
 
         if self.alarm.arm_status in ['disarming', 'disarmed']:
             status = 'System already %s, ignoring request' % self.alarm.arm_status


### PR DESCRIPTION
Change for issue #13 
- Updated AlarmConfig to expose the ConfigParser object, allow users of AlarmConfig to call any ConfigParser API, e.g. getboolean()
- Fixed a bug where calling 'alarm-ctl disarm' should trigger a notification, but it was being muted if the system was previously armed using 'alarm-ctl auto-arm'
