### PR TITLE
Gracefully handle missing RpiArmDisarm config

### DIFF
--- a/alarm_central_station_receiver/system.py
+++ b/alarm_central_station_receiver/system.py
@@ -64,7 +64,9 @@ class AlarmSystem(object):
         GPIO.setup(self.pin, GPIO.OUT)
 
     def __init__(self):
-        self.pin = AlarmConfig.config.getint('RpiArmDisarm', 'gpio_pin')
+        self.pin = AlarmConfig.config.getint('RpiArmDisarm',
+                                             'gpio_pin',
+                                             fallback=None)
         if not self.valid_setup():
             return
 


### PR DESCRIPTION
An exception is thrown when system.py attempts to load optional config RpiArmDisarm.  If the config is missing it should not throw an exception.  See https://github.com/scudre/alarm-central-station-receiver/issues/41#issuecomment-421479546