### PR TITLE
Fixed AlarmSystem exception when no GPIO pin set in config

### DIFF
--- a/alarm_central_station_receiver/system.py
+++ b/alarm_central_station_receiver/system.py
@@ -64,13 +64,13 @@ class AlarmSystem(object):
         GPIO.setup(self.pin, GPIO.OUT)
 
     def __init__(self):
+        self.alarm = AlarmStatus()
         self.pin = AlarmConfig.config.getint('RpiArmDisarm',
                                              'gpio_pin',
                                              fallback=None)
         if not self.valid_setup():
             return
 
-        self.alarm = AlarmStatus()
         self._initialize_rpi_gpio()
 
     def arm(self, auto_arm):


### PR DESCRIPTION
Exception was seen by @ljsanchez https://github.com/scudre/alarm-central-station-receiver/issues/41#issuecomment-433643564

When a GPIO pin isn't configured in the alarm config, AlarmSystem was not initializing the alarm status.  When main.py attempted to check the alarm system's state it cause an exception.  Instead we should always initialize the alarm stauts in AlarmSystem, even if a user is only going to monitor the system, and won't be arming/disarming (which is what the GPIO config is for.)