### PR TITLE
Create alarmd config directory if missing

### DIFF
--- a/alarm_central_station_receiver/config_template.ini
+++ b/alarm_central_station_receiver/config_template.ini
@@ -11,7 +11,7 @@
 notify_auto_events = false
 
 # Location to save alarmd state data
-data_file_path = /var/lib/alarmd/alarmd.db
+data_file_path = /var/lib/alarmd/
 
 # Phone number your alarm system will dial.  Alarmd will initiate the contact-id
 # handshake when it detects your alarm calling this number.


### PR DESCRIPTION
If the alarmd config directory is missing on load, create it.  Without the directory present, the alarm state cannot be saved after an event.